### PR TITLE
Indicate winners more accurately

### DIFF
--- a/_layouts/organization.html
+++ b/_layouts/organization.html
@@ -559,13 +559,13 @@ font-size: 1.25em; line-height: 1; margin-bottom: 3rem;">Submitted Ideas</h2>
 {% assign is_winner = false %}
 {% for winner in site.data.winners %}
   {% assign secure_challenge_url = project.challenge_url | replace: "http://", "https://" %}
-  {% if winner == secure_challenge_url %}
+  {% if winner.url contains secure_challenge_url or secure_challenge_url contains winner.url %}
     {% assign is_winner = true %}
   {% endif %}
 
   {% for challenge_url in page.aggregated.challenge_url %}
     {% assign secure_challenge_url = challenge_url | replace: "http://", "https://" %}
-    {% if winner.url == secure_challenge_url %}
+    {% if winner.url contains secure_challenge_url or secure_challenge_url contains winner.url %}
       {% if project.year_submitted == 2018 %}
         {% if challenge_url contains "activation" %}
           {% assign is_winner = true %}

--- a/_layouts/project-list.html
+++ b/_layouts/project-list.html
@@ -302,7 +302,7 @@ align-self: stretch;
   {% for winner in site.data.winners %}
     {% for challenge_url in data.aggregated.challenge_url %}
       {% assign secure_challenge_url = challenge_url | replace: "http://", "https://" %}
-      {% if winner.url == secure_challenge_url %}
+      {% if winner.url contains secure_challenge_url or secure_challenge_url contains winner.url %}
         {% assign is_winner = true %}
         {% assign winner_year = winner.year %}
       {% endif %}

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -50,13 +50,13 @@ stylesheets:
 {% assign is_winner = false %}
 {% for winner in site.data.winners %}
   {% assign secure_challenge_url = page.challenge_url | replace: "http://", "https://" %}
-  {% if winner == secure_challenge_url %}
+  {% if winner.url contains secure_challenge_url or secure_challenge_url contains winner.url %}
     {% assign is_winner = true %}
   {% endif %}
 
   {% for challenge_url in organization.aggregated.challenge_url %}
     {% assign secure_challenge_url = challenge_url | replace: "http://", "https://" %}
-    {% if winner.url == secure_challenge_url %}
+    {% if winner.url contains secure_challenge_url or secure_challenge_url contains winner.url %}
       {% if page.year_submitted == 2018 %}
         {% if challenge_url contains "activation" %}
           {% assign is_winner = true %}


### PR DESCRIPTION
Handle the case where a winner URL has a trailing slash that doesn’t quite match a project URL